### PR TITLE
Fix: 使用wmts加载北京

### DIFF
--- a/src/tianditu_province/天地图-北京.disable.yml
+++ b/src/tianditu_province/天地图-北京.disable.yml
@@ -1,0 +1,14 @@
+- name: 北京 - 2024年01月影像
+  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202401/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+- name: 北京 - 2023年06月影像
+  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202306/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+- name: 北京 - 2023年03月影像
+  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202303/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+- name: 北京 - 2022年12月影像
+  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202212/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+- name: 北京 - 2022年09月影像
+  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202209/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+- name: 北京 - 2022年06月影像
+  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202206/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+- name: 北京 - 2022年03月影像
+  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202203/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7

--- a/src/tianditu_province/天地图-北京.yml
+++ b/src/tianditu_province/天地图-北京.yml
@@ -1,14 +1,14 @@
 - name: 北京 - 2024年01月影像
-  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202401/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+  uri: crs=EPSG:3857&dpiMode=7&featureCount=10&format=image/png&layers=bj_202401&styles=default&tileMatrixSet=GLOBAL_WEBMERCATOR&tilePixelRatio=0&url=https://maps.liuxs.pro/wmts/beijing.xml
 - name: 北京 - 2023年06月影像
-  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202306/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+  uri: crs=EPSG:3857&dpiMode=7&featureCount=10&format=image/png&layers=bj_202306&styles=default&tileMatrixSet=GLOBAL_WEBMERCATOR&tilePixelRatio=0&url=https://maps.liuxs.pro/wmts/beijing.xml
 - name: 北京 - 2023年03月影像
-  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202303/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+  uri: crs=EPSG:3857&dpiMode=7&featureCount=10&format=image/png&layers=bj_202303&styles=default&tileMatrixSet=GLOBAL_WEBMERCATOR&tilePixelRatio=0&url=https://maps.liuxs.pro/wmts/beijing.xml
 - name: 北京 - 2022年12月影像
-  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202212/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+  uri: crs=EPSG:3857&dpiMode=7&featureCount=10&format=image/png&layers=bj_202212&styles=default&tileMatrixSet=GLOBAL_WEBMERCATOR&tilePixelRatio=0&url=https://maps.liuxs.pro/wmts/beijing.xml
 - name: 北京 - 2022年09月影像
-  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202209/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+  uri: crs=EPSG:3857&dpiMode=7&featureCount=10&format=image/png&layers=bj_202209&styles=default&tileMatrixSet=GLOBAL_WEBMERCATOR&tilePixelRatio=0&url=https://maps.liuxs.pro/wmts/beijing.xml
 - name: 北京 - 2022年06月影像
-  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202206/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+  uri: crs=EPSG:3857&dpiMode=7&featureCount=10&format=image/png&layers=bj_202206&styles=default&tileMatrixSet=GLOBAL_WEBMERCATOR&tilePixelRatio=0&url=https://maps.liuxs.pro/wmts/beijing.xml
 - name: 北京 - 2022年03月影像
-  uri: type=xyz&url=https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202203/zxyTileImage/%7Bz%7D/%7Bx%7D/%7By%7D.png?width%3D256%26height%3D256%26transparent%3Dtrue&zmax=18&zmin=7
+  uri: crs=EPSG:3857&dpiMode=7&featureCount=10&format=image/png&layers=bj_202203&styles=default&tileMatrixSet=GLOBAL_WEBMERCATOR&tilePixelRatio=0&url=https://maps.liuxs.pro/wmts/beijing.xml

--- a/wmts/beijing.xml
+++ b/wmts/beijing.xml
@@ -1,0 +1,315 @@
+<?xml version="1.0"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0"
+    xmlns:ows="http://www.opengis.net/ows/1.1"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
+    <ows:ServiceIdentification>
+        <ows:Title>Debug Tile</ows:Title>
+        <ows:Abstract>Debug Tile by liuxspro</ows:Abstract>
+        <ows:ServiceType>OGC WMTS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+        <ows:Fees>none</ows:Fees>
+        <ows:AccessConstraints>none</ows:AccessConstraints>
+    </ows:ServiceIdentification>
+    <Contents>
+        <Layer>
+            <ows:Title>北京 - 2024年01月影像</ows:Title>
+            <ows:Abstract>北京 - 2024年01月影像</ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>115.413811 39.443493</ows:LowerCorner>
+                <ows:UpperCorner>117.506111 41.058609</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>bj_202401</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>GLOBAL_WEBMERCATOR</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202401/zxyTileImage/{TileMatrix}/{TileCol}/{TileRow}.png?width=256&amp;height=256&amp;transparent=true" />
+        </Layer>
+        <Layer>
+            <ows:Title>北京 - 2023年06月影像</ows:Title>
+            <ows:Abstract>北京 - 2023年06月影像</ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>115.413811 39.443493</ows:LowerCorner>
+                <ows:UpperCorner>117.506111 41.058609</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>bj_202306</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>GLOBAL_WEBMERCATOR</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202306/zxyTileImage/{TileMatrix}/{TileCol}/{TileRow}.png?width=256&amp;height=256&amp;transparent=true" />
+        </Layer>
+        <Layer>
+            <ows:Title>北京 - 2023年03月影像</ows:Title>
+            <ows:Abstract>北京 - 2023年03月影像</ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>115.413811 39.443493</ows:LowerCorner>
+                <ows:UpperCorner>117.506111 41.058609</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>bj_202303</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>GLOBAL_WEBMERCATOR</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202303/zxyTileImage/{TileMatrix}/{TileCol}/{TileRow}.png?width=256&amp;height=256&amp;transparent=true" />
+        </Layer>
+        <Layer>
+            <ows:Title>北京 - 2022年12月影像</ows:Title>
+            <ows:Abstract>北京 - 2022年12月影像</ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>115.413811 39.443493</ows:LowerCorner>
+                <ows:UpperCorner>117.506111 41.058609</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>bj_202212</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>GLOBAL_WEBMERCATOR</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202212/zxyTileImage/{TileMatrix}/{TileCol}/{TileRow}.png?width=256&amp;height=256&amp;transparent=true" />
+        </Layer>
+        <Layer>
+            <ows:Title>北京 - 2022年09月影像</ows:Title>
+            <ows:Abstract>北京 - 2022年09月影像</ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>115.413811 39.443493</ows:LowerCorner>
+                <ows:UpperCorner>117.506111 41.058609</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>bj_202209</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>GLOBAL_WEBMERCATOR</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202209/zxyTileImage/{TileMatrix}/{TileCol}/{TileRow}.png?width=256&amp;height=256&amp;transparent=true" />
+        </Layer>
+        <Layer>
+            <ows:Title>北京 - 2022年06月影像</ows:Title>
+            <ows:Abstract>北京 - 2022年06月影像</ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>115.413811 39.443493</ows:LowerCorner>
+                <ows:UpperCorner>117.506111 41.058609</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>bj_202206</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>GLOBAL_WEBMERCATOR</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202206/zxyTileImage/{TileMatrix}/{TileCol}/{TileRow}.png?width=256&amp;height=256&amp;transparent=true" />
+        </Layer>
+        <Layer>
+            <ows:Title>北京 - 2022年03月影像</ows:Title>
+            <ows:Abstract>北京 - 2022年03月影像</ows:Abstract>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>115.413811 39.443493</ows:LowerCorner>
+                <ows:UpperCorner>117.506111 41.058609</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:Identifier>bj_202203</ows:Identifier>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>GLOBAL_WEBMERCATOR</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202203/zxyTileImage/{TileMatrix}/{TileCol}/{TileRow}.png?width=256&amp;height=256&amp;transparent=true" />
+        </Layer>
+        <!-- 瓦片矩阵集 -->
+        <!-- 3857 与 XYZ 瓦片兼容 -->
+        <TileMatrixSet>
+            <ows:Title>Google Maps Compatible for the World</ows:Title>
+            <ows:Identifier>GLOBAL_WEBMERCATOR</ows:Identifier>
+            <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.18.3:3857</ows:SupportedCRS>
+            <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>
+            <TileMatrix>
+                <ows:Identifier>0</ows:Identifier>
+                <ScaleDenominator>559082264.0287178</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>1</MatrixWidth>
+                <MatrixHeight>1</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>1</ows:Identifier>
+                <ScaleDenominator>279541132.0143589</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>2</MatrixWidth>
+                <MatrixHeight>2</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>2</ows:Identifier>
+                <ScaleDenominator>139770566.0071794</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>4</MatrixWidth>
+                <MatrixHeight>4</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>3</ows:Identifier>
+                <ScaleDenominator>69885283.00358972</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>8</MatrixWidth>
+                <MatrixHeight>8</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>4</ows:Identifier>
+                <ScaleDenominator>34942641.50179486</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>16</MatrixWidth>
+                <MatrixHeight>16</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>5</ows:Identifier>
+                <ScaleDenominator>17471320.75089743</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>32</MatrixWidth>
+                <MatrixHeight>32</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>6</ows:Identifier>
+                <ScaleDenominator>8735660.375448715</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>64</MatrixWidth>
+                <MatrixHeight>64</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>7</ows:Identifier>
+                <ScaleDenominator>4367830.187724357</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>128</MatrixWidth>
+                <MatrixHeight>128</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>8</ows:Identifier>
+                <ScaleDenominator>2183915.093862179</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>256</MatrixWidth>
+                <MatrixHeight>256</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>9</ows:Identifier>
+                <ScaleDenominator>1091957.546931089</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>512</MatrixWidth>
+                <MatrixHeight>512</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>10</ows:Identifier>
+                <ScaleDenominator>545978.7734655447</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>1024</MatrixWidth>
+                <MatrixHeight>1024</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>11</ows:Identifier>
+                <ScaleDenominator>272989.3867327723</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>2048</MatrixWidth>
+                <MatrixHeight>2048</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>12</ows:Identifier>
+                <ScaleDenominator>136494.6933663862</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>4096</MatrixWidth>
+                <MatrixHeight>4096</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>13</ows:Identifier>
+                <ScaleDenominator>68247.34668319309</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>8192</MatrixWidth>
+                <MatrixHeight>8192</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>14</ows:Identifier>
+                <ScaleDenominator>34123.67334159654</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>16384</MatrixWidth>
+                <MatrixHeight>16384</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>15</ows:Identifier>
+                <ScaleDenominator>17061.83667079827</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>32768</MatrixWidth>
+                <MatrixHeight>32768</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>16</ows:Identifier>
+                <ScaleDenominator>8530.918335399136</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>65536</MatrixWidth>
+                <MatrixHeight>65536</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>17</ows:Identifier>
+                <ScaleDenominator>4265.459167699568</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>131072</MatrixWidth>
+                <MatrixHeight>131072</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>18</ows:Identifier>
+                <ScaleDenominator>2132.729583849784</ScaleDenominator>
+                <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>262114</MatrixWidth>
+                <MatrixHeight>262114</MatrixHeight>
+            </TileMatrix>
+        </TileMatrixSet>
+    </Contents>
+</Capabilities>


### PR DESCRIPTION
使用XYZ加载北京天地图时，由于没有图层范围没有限制
导致请求大量无效瓦片，QGIS容易卡死
```
https://beijing.tianditu.gov.cn/iserver/services/map-2022_img/rest/maps/tdt_img_202401/zxyTileImage/{z}/{x}/{y}.png?width=256&height=256&transparent=true
```
于是改用WMTS，并限定范围
